### PR TITLE
docs: expand README with detailed configuration guide and usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ If you want someone to help you with this implementation, just open an issue.
 
 
 ### Notice
-This is just a proof of concept of MCP. As I see it, much can be done to make it more useful with embedded devices, home assistants, or documentation. If you have any ideas, we can discuss them in the issues.
+This project is currently a **Proof of Concept (PoC)** for an MCP server tailored for ESP-IDF workflows. 
+
+**Current Capabilities:**
+*   Supports basic ESP-IDF project build commands.
+*   Includes experimental support for automatic issue fixing based on build logs.
+
+**Vision & Future Work:**
+The long-term vision is to expand this MCP into a comprehensive toolkit for interacting with embedded devices, potentially integrating with home assistant platforms, and streamlining documentation access for ESP-IDF and related technologies. 
+
+We envision features such as:
+*   Broader ESP-IDF command support (e.g., `monitor`, `menuconfig` interaction if feasible).
+*   Device management and information retrieval.
+*   Integration with other embedded development tools and platforms.
+
+Your ideas and contributions are welcome! Please feel free to discuss them by opening an issue.
 
 
 ### Install  
@@ -24,23 +38,45 @@ git clone git@github.com:horw/esp-mcp.git
 
 Then, configure it in your chatbot. 
 
+The JSON snippet below is an example of how you might configure this `esp-mcp` server within a chatbot or an agent system that supports the Model Context Protocol (MCP). The exact configuration steps and format may vary depending on the specific chatbot system you are using. Refer to your chatbot's documentation for details on how to integrate MCP servers.
 
 ```json
 {
     "mcpServers": {
-        "esp-run": {
-            "command": "/home/horw/.pyenv/shims/uv",
+        "esp-run": { // "esp-run" is an arbitrary name you can assign to this server configuration.
+            "command": "<path_to_uv_or_python_executable>",
             "args": [
                 "--directory",
-                "/home/horw/PycharmProjects/esp-mcp", <- your cloned path
+                "<path_to_cloned_esp-mcp_repository>", // e.g., /path/to/your/cloned/esp-mcp
                 "run",
-                "main.py"
+                "main.py" // If using python directly, this might be just "main.py" and `command` would be your python interpreter
             ],
             "env": {
-                "IDF_PATH": "~/esp-idf" <- your ESP-IDF path
+                "IDF_PATH": "<path_to_your_esp-idf_directory>" // e.g., ~/esp/esp-idf or C:\\Espressif\\frameworks\\esp-idf
             }
         }
     }
 }
-```  
+```
+
+A few notes on the configuration:
+
+*   **`command`**: This should be the full path to your `uv` executable if you are using it, or your Python interpreter (e.g., `/usr/bin/python3` or `C:\\Python39\\python.exe`) if you plan to run `main.py` directly.
+*   **`args`**:
+    *   The first argument to `--directory` should be the absolute path to where you cloned the `esp-mcp` repository.
+    *   If you're using `uv`, the arguments `run main.py` are appropriate. If you're using Python directly, you might only need `main.py` in the `args` list, and ensure your `command` points to the Python executable.
+*   **`IDF_PATH`**: This environment variable must point to the root directory of your ESP-IDF installation. ESP-IDF is Espressif's official IoT Development Framework. If you haven't installed it, please refer to the [official ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/index.html) for installation instructions.
+
+### Usage
+
+Once the `esp-mcp` server is configured and running, your LLM or chatbot can interact with it using the tools defined in this MCP. For example, you could ask your chatbot to:
+
+*   "Build the project located at `/path/to/my/esp-project` using the `esp-mcp`."
+*   "Clean the build files for the ESP32 project in the `examples/hello_world` directory."
+*   "Flash the firmware to my connected ESP32 device for the project in `my_app`."
+
+The MCP server will then execute the corresponding ESP-IDF commands (like `idf.py build`, `idf.py fullclean`, `idf.py flash`) based on the tools implemented in `main.py`.
+
+The `result.gif` below shows an example interaction:
+
 ![Result](./result.gif)


### PR DESCRIPTION
This PR addresses issue #33 by significantly improving the `README.md` to enhance clarity and user-friendliness.

The following changes have been implemented:

- __Generalized Installation Paths:__ The hardcoded paths in the JSON configuration example under the "Install" section have been replaced with descriptive placeholders (e.g., `<path_to_cloned_esp-mcp_repository>`, `<path_to_your_esp-idf_directory>`). This makes it easier for users to adapt the configuration to their own environments.
- __Clarified Configuration Parameters:__ Added detailed explanations for `command`, `args`, and `IDF_PATH` within the installation instructions. This includes guidance on using `uv` versus a direct Python interpreter and a link to the official ESP-IDF documentation for `IDF_PATH` setup.
- __Expanded Chatbot Configuration Guidance:__ The "Install" section now provides more context on how the example JSON snippet is used for configuring the MCP server within a chatbot or agent system, advising users to refer to their specific chatbot's documentation.
- __Added "Usage" Section:__ A new "Usage" section has been introduced, providing example prompts that users can give to their LLM/chatbot to interact with the `esp-mcp` server (e.g., building, cleaning, flashing projects).
- __Enhanced "Notice" Section:__ The "Notice" section has been expanded to better define the project's Proof of Concept (PoC) status. It now clearly lists current capabilities and outlines the vision for future work and potential features, setting appropriate expectations for users and contributors.
