### PR TITLE
feat: support set-target and create project

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,6 +47,28 @@ async def setup_project_esp_target(project_path: str, target: str) -> (str, str)
 
 
 @mcp.tool()
+async def create_esp_project(project_path: str, project_name: str) -> (str, str):
+    """
+    Creates a new ESP-IDF project for an ESP chip.
+
+    Args:
+        project_path (str): Path where the new ESP-IDF project will be created. 
+                            Must be located directly under the current working directory.
+        project_name (str): Name of the ESP-IDF project to create.
+
+    Returns:
+        Tuple[str, str]: A tuple containing the standard output and standard error messages.
+    """
+    os.makedirs(project_path, exist_ok=True)
+    os.chdir(project_path)
+    export_script = get_export_script()
+    returncode, stdout, stderr = await run_command_async(f"bash -c 'source {export_script} && idf.py create-project --path {project_path} {project_name}'")
+    open('mcp-project-root-path.log', 'w+').write(str((stdout, stderr)))
+    logging.warning(f"build result {stdout} {stderr}")
+    return stdout, stderr
+
+
+@mcp.tool()
 async def flash_esp_project(project_path: str, port: str = None) -> (str, str):
     """Flash built firmware to a connected ESP device.
 

--- a/main.py
+++ b/main.py
@@ -25,6 +25,27 @@ async def build_esp_related_project(project_path: str) -> (str, str):
     logging.warning(f"build result {stdout} {stderr}")
     return stdout, stderr
 
+
+@mcp.tool()
+async def setup_project_esp_target(project_path: str, target: str) -> (str, str):
+    """
+    Sets up the target for an ESP-IDF project before building.
+
+    Args:
+        project_path (str): Path to the ESP-IDF project.
+        target (str): Lowercase target name, such as 'esp32' or 'esp32c3'.
+
+    Returns:
+        Tuple[str, str]: A tuple containing the standard output and standard error.
+    """
+    os.chdir(project_path)
+    export_script = get_export_script()
+    returncode, stdout, stderr = await run_command_async(f"bash -c 'source {export_script} && idf.py set-target {target}'")
+    open('mcp-set-target.log', 'w+').write(str((stdout, stderr)))
+    logging.warning(f"build result {stdout} {stderr}")
+    return stdout, stderr
+
+
 @mcp.tool()
 async def flash_esp_project(project_path: str, port: str = None) -> (str, str):
     """Flash built firmware to a connected ESP device.


### PR DESCRIPTION
- Adds `setup_project_esp_target` tool to set the device target (e.g., `esp32`, `esp32c3`) for an ESP-IDF project.
- Adds `create_esp_project` tool to create new esp32 project.

Closes #4 

POC:
![image](https://github.com/user-attachments/assets/6a7e445f-1f54-47d6-9397-59c9676cb10e)
![image](https://github.com/user-attachments/assets/2674bd66-94a1-420a-8cb1-c92cd6d74489)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to set the ESP-IDF project target (such as "esp32" or "esp32c3") directly from the interface, with results and errors logged for user reference.
	- Introduced a feature to create new ESP-IDF projects through the interface, including logging of process output and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->